### PR TITLE
Fixed command in doc (changed ";" to "/")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 CubiePio
 ========
 
-This program is based on pio sunxi tools but it works on Cubitruck lunbutu. 
+This program is based on pio sunxi tools but it works on Cubitruck lunbutu.
 with this tools you don't need to change fex file.
 
-To setup a pin : 
-pio -m PINBR;mode;pullup;drive;value
+To setup a pin :
+pio -m PINBR/mode/pullup/drive/value
 
 PINBR : for pin number on extension port see : http://linux-sunxi.org/Cubietruck#Expansion_Ports
 
 for the mode is are : 0 for input, 1 for output and for other see mux on : http://docs.cubieboard.org/a20-cubietruck_gpio_pin
 
-activate the pullup : 1 or 0 to disable 
+activate the pullup : 1 or 0 to disable
 
 drive : defines the output drive in mA, values are 0-3 corresponding to 10mA, 20mA, 30mA and 40mA.
 
-value : 0 or 1 
+value : 0 or 1
 
-sample : sudo pio PC21;1;0;0;1 put the pin PC21 (near the ethernet port) at 3,3V
+sample : sudo pio PC21/1/0/0/1 put the pin PC21 (near the ethernet port) at 3,3V


### PR DESCRIPTION
I installed and tested your tool on my cubietruck.
I found out in your code you seperate the information to set pins by "/" instead of ";" as written in the README.
